### PR TITLE
[cedra-release-v1.0.0] Bump version to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4811,7 +4811,7 @@ dependencies = [
 
 [[package]]
 name = "cedra-node"
-version = "0.0.0-main"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bcs 0.1.4",

--- a/cedra-node/Cargo.toml
+++ b/cedra-node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cedra-node"
 description = "Cedra node"
-version = "0.0.0-main"
+version = "1.0.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This PR bumps the cedra-node version to 1.0.0 in cedra-release-v1.0.0.